### PR TITLE
Fix missing ... in args forwarded to printf-like function

### DIFF
--- a/kmsgparser/kmsgparser_test.go
+++ b/kmsgparser/kmsgparser_test.go
@@ -36,10 +36,10 @@ type warningAndErrorTestLogger struct {
 
 func (warningAndErrorTestLogger) Infof(string, ...interface{}) {}
 func (w warningAndErrorTestLogger) Warningf(s string, i ...interface{}) {
-	w.t.Errorf(s, i)
+	w.t.Errorf(s, i...)
 }
 func (w warningAndErrorTestLogger) Errorf(s string, i ...interface{}) {
-	w.t.Errorf(s, i)
+	w.t.Errorf(s, i...)
 }
 
 func TestParseMessage(t *testing.T) {


### PR DESCRIPTION
Fix:
```
Testing: "/builddir/build/BUILD/go-kmsg-parser-2.0.0/_build/src/github.com/euank/go-kmsg-parser/kmsgparser"
+ GOPATH=/builddir/build/BUILD/go-kmsg-parser-2.0.0/_build:/usr/share/gocode
+ go test -buildmode pie -compiler gc -ldflags '-extldflags '\''-Wl,-z,relro -Wl,--as-needed  -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld '\'''
# github.com/euank/go-kmsg-parser/kmsgparser
./kmsgparser_test.go:39: missing ... in args forwarded to printf-like function
./kmsgparser_test.go:42: missing ... in args forwarded to printf-like function
FAIL	github.com/euank/go-kmsg-parser/kmsgparser [build failed]
```

Tested in Fedora rawhide https://koji.fedoraproject.org/koji/taskinfo?taskID=30597664