### PR TITLE
go.mod: add correct 'v2' suffix

### DIFF
--- a/cmd/godmesg/main.go
+++ b/cmd/godmesg/main.go
@@ -22,7 +22,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/euank/go-kmsg-parser/kmsgparser"
+	"github.com/euank/go-kmsg-parser/v2/kmsgparser"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/euank/go-kmsg-parser
+module github.com/euank/go-kmsg-parser/v2
 
 go 1.14
 


### PR DESCRIPTION
Since this is tagged v2, it needs the v2 suffix to not confuse go
modules.

Fixes #6