### PR TITLE
Allow stopping reading at the end of the circular buffer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,3 @@
-module github.com/euank/go-kmsg-parser/v2
+module github.com/euank/go-kmsg-parser/v3
 
-go 1.14
-
-require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.2.2
-)
+go 1.18

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,0 @@
-github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
-github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
-github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
-github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/kmsgparser/kmsgparser.go
+++ b/kmsgparser/kmsgparser.go
@@ -22,6 +22,7 @@ limitations under the License.
 package kmsgparser
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -35,13 +36,12 @@ import (
 type Parser interface {
 	// SeekEnd moves the parser to the end of the kmsg queue.
 	SeekEnd() error
-	// Parse provides a channel of messages read from the kernel ring buffer.
-	// When first called, it will read the existing ringbuffer, after which it will emit new messages as they occur.
-	Parse() <-chan Message
-	// SetLogger sets the logger that will be used to report malformed kernel
-	// ringbuffer lines or unexpected kmsg read errors.
-	SetLogger(Logger)
-	// Close closes the underlying kmsg reader for this parser
+	// Parse reads from kmsg and provides a channel of messages.
+	//
+	// Parse will run a goroutine to process messages. Calling 'Close()' will
+	// result in the goroutine exiting and the returned channel being closed.
+	Parse() (<-chan Message, error)
+
 	Close() error
 }
 
@@ -56,7 +56,8 @@ type Message struct {
 	Message        string
 }
 
-func NewParser() (Parser, error) {
+// NewParser constructs a new parser with the given Options.
+func NewParser(opts ...Option) (Parser, error) {
 	f, err := os.Open("/dev/kmsg")
 	if err != nil {
 		return nil, err
@@ -66,23 +67,44 @@ func NewParser() (Parser, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	return &parser{
+	p := &parser{
 		log:        &StandardLogger{nil},
 		kmsgReader: f,
 		bootTime:   bootTime,
-	}, nil
+		follow:     true,
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p, nil
 }
 
-type ReadSeekCloser interface {
-	io.ReadCloser
-	io.Seeker
+// Option is a configuration option for [NewParser]
+type Option func(p *parser)
+
+// WithNoFollow configures [Parser] to stop reading and close the channel when
+// it reaches the end of the kmsg buffer.
+func WithNoFollow() func(p *parser) {
+	return func(p *parser) {
+		p.follow = false
+	}
+}
+
+// WithLogger configures the [Parser]'s [Logger]
+func WithLogger(log Logger) func(p *parser) {
+	return func(p *parser) {
+		p.log = log
+	}
 }
 
 type parser struct {
 	log        Logger
-	kmsgReader ReadSeekCloser
+	kmsgReader *os.File
 	bootTime   time.Time
+	// follow indicates whether we should stop when we hit the end of the kmsg
+	// buffer, or keep reading. Similar to dmesg --follow.
+	// Default true
+	follow bool
 }
 
 func getBootTime() (time.Time, error) {
@@ -95,31 +117,32 @@ func getBootTime() (time.Time, error) {
 	return time.Now().Add(-1 * (time.Duration(sysinfo.Uptime) * time.Second)), nil
 }
 
-func (p *parser) SetLogger(log Logger) {
-	p.log = log
+func (p *parser) SeekEnd() error {
+	_, err := p.kmsgReader.Seek(0, io.SeekEnd)
+	return err
 }
 
 func (p *parser) Close() error {
 	return p.kmsgReader.Close()
 }
 
-func (p *parser) SeekEnd() error {
-	_, err := p.kmsgReader.Seek(0, io.SeekEnd)
-	return err
-}
-
-// Parse will read from the provided reader and provide a channel of messages
+// Parse reads from the provided reader and provide a channel of messages
 // parsed.
 // If the provided reader *is not* a proper Linux kmsg device, Parse might not
 // behave correctly since it relies on specific behavior of `/dev/kmsg`
 //
-// A goroutine is created to process the provided reader. The goroutine will
-// exit when the given reader is closed.
-// Closing the passed in reader will cause the goroutine to exit.
-func (p *parser) Parse() <-chan Message {
+// The caller should typically run 'Parse' in a goroutine.
+// Closing the passed in context will cause the goroutine to exit.
+func (p *parser) Parse() (<-chan Message, error) {
+	// with follow (dmesg --follow), we can use go's usual way of reading thing (i.e. epoll + nonblocking IO).
+	if p.follow {
+		return p.readFollow()
+	}
+	return p.readNofollow()
+}
 
+func (p *parser) readFollow() (<-chan Message, error) {
 	output := make(chan Message, 1)
-
 	go func() {
 		defer close(output)
 		msg := make([]byte, 8192)
@@ -127,6 +150,17 @@ func (p *parser) Parse() <-chan Message {
 			// Each read call gives us one full message.
 			// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
 			n, err := p.kmsgReader.Read(msg)
+			switch {
+			case err == nil:
+			case errors.Is(err, syscall.EPIPE):
+				p.log.Warningf("short read from kmsg; skipping")
+				continue
+			case errors.Is(err, io.EOF):
+				// user closed the file
+				return
+			default:
+				p.log.Warningf("unexpected error: %v", err)
+			}
 			if err != nil {
 				if err == syscall.EPIPE {
 					p.log.Warningf("short read from kmsg; skipping")
@@ -149,12 +183,67 @@ func (p *parser) Parse() <-chan Message {
 				p.log.Warningf("unable to parse kmsg message %q: %v", msgStr, err)
 				continue
 			}
-
 			output <- message
 		}
 	}()
+	return output, nil
+}
 
-	return output
+func (p *parser) readNofollow() (<-chan Message, error) {
+	rawReader, err := p.kmsgReader.SyscallConn()
+	if err != nil {
+		return nil, err
+	}
+	// we're forced to put the fd into non-blocking mode to be able to detect the
+	// end of the buffer, but to not use go's built-in epoll
+	if ctrlErr := rawReader.Control(func(fd uintptr) {
+		err = syscall.SetNonblock(int(fd), true)
+	}); ctrlErr != nil {
+		return nil, fmt.Errorf("error calling control on kmsg reader: %w", ctrlErr)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("unable to set nonblocking on fd: %w", err)
+	}
+	output := make(chan Message, 1)
+	go func() {
+		defer close(output)
+		msg := make([]byte, 8192)
+		for {
+			// Each read call gives us one full message.
+			// https://www.kernel.org/doc/Documentation/ABI/testing/dev-kmsg
+			var err error
+			var n int
+			if readErr := rawReader.Read(func(fd uintptr) bool {
+				n, err = syscall.Read(int(fd), msg)
+				return true
+			}); readErr != nil {
+				p.log.Warningf("unable to call Read on RawConn: %w", readErr)
+				// probably means somehow our fd got closed, right? There's not much else it could be.
+				// Give up on it.
+				return
+			}
+			switch {
+			case err == nil:
+			case errors.Is(err, syscall.EPIPE):
+				p.log.Warningf("short read from kmsg; skipping")
+				continue
+			case errors.Is(err, syscall.EAGAIN):
+				// end of ring buffer in nofollow mode, we're done
+				return
+			default:
+				p.log.Warningf("unexpected error: %v", err)
+			}
+			msgStr := string(msg[:n])
+
+			message, err := p.parseMessage(msgStr)
+			if err != nil {
+				p.log.Warningf("unable to parse kmsg message %q: %v", msgStr, err)
+				continue
+			}
+			output <- message
+		}
+	}()
+	return output, nil
 }
 
 func (p *parser) parseMessage(input string) (Message, error) {

--- a/kmsgparser/kmsgparser_test.go
+++ b/kmsgparser/kmsgparser_test.go
@@ -17,16 +17,8 @@ limitations under the License.
 package kmsgparser
 
 import (
-	"bufio"
-	"bytes"
-	"io"
-	"io/ioutil"
-	"os"
-	"path/filepath"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Logger that errors on warnings and errors
@@ -53,93 +45,14 @@ func TestParseMessage(t *testing.T) {
 		t.Fatalf("error parsing: %v", err)
 	}
 
-	assert.Equal(t, msg.Message, "docker0: port 2(vethc1bb733) entered blocking state")
-
-	assert.Equal(t, msg.Priority, 6)
-	assert.Equal(t, msg.SequenceNumber, 2565)
-	assert.Equal(t, msg.Timestamp, bootTime.Add(102258085667*time.Microsecond))
+	assertEqual(t, msg.Message, "docker0: port 2(vethc1bb733) entered blocking state")
+	assertEqual(t, msg.Priority, 6)
+	assertEqual(t, msg.SequenceNumber, 2565)
+	assertEqual(t, msg.Timestamp, bootTime.Add(102258085667*time.Microsecond))
 }
 
-func TestParse(t *testing.T) {
-	bootTime := time.Unix(0xb100, 0x5ea1).Round(time.Microsecond)
-	p := parser{
-		log:      warningAndErrorTestLogger{t: t},
-		bootTime: bootTime,
+func assertEqual[T comparable](t *testing.T, lhs, rhs T) {
+	if lhs != rhs {
+		t.Fatalf("expected %v = %v", lhs, rhs)
 	}
-	f, err := os.Open(filepath.Join("test_data", "sample1.kmsg"))
-	if err != nil {
-		t.Fatalf("could not find sample data: %v", err)
-	}
-	defer f.Close()
-
-	expectedMessages := []Message{
-		{
-			Priority:       6,
-			SequenceNumber: 1804,
-			Timestamp:      bootTime.Add(47700428483 * time.Microsecond),
-			Message:        "wlp4s0: associated",
-		},
-		{
-			Priority:       6,
-			SequenceNumber: 1805,
-			Timestamp:      bootTime.Add(51742248189 * time.Microsecond),
-			Message:        "thinkpad_acpi: EC reports that Thermal Table has changed",
-		},
-		{
-			Priority:       6,
-			SequenceNumber: 2651,
-			Timestamp:      bootTime.Add(106819644585 * time.Microsecond),
-			Message:        "CPU1: Package temperature/speed normal",
-		},
-	}
-
-	s := bufio.NewScanner(f)
-	mockKmsg, mockKmsgInput := io.Pipe()
-	p.kmsgReader = mockSeeker(ioutil.NopCloser(mockKmsg))
-	go func() {
-		for s.Scan() {
-			_, err := mockKmsgInput.Write(s.Bytes())
-			if err != nil {
-				panic(err)
-			}
-		}
-		mockKmsgInput.Close()
-	}()
-
-	lines := p.Parse()
-
-	messages := []Message{}
-	for line := range lines {
-		messages = append(messages, line)
-	}
-
-	assert.Equal(t, expectedMessages, messages)
-}
-
-func TestSeekEnd(t *testing.T) {
-	p := parser{
-		log: warningAndErrorTestLogger{t: t},
-	}
-	var mockKmsg bytes.Buffer
-	mockkmsg := mockSeeker(ioutil.NopCloser(&mockKmsg))
-	p.kmsgReader = mockkmsg
-
-	err := p.SeekEnd()
-	assert.Nil(t, err)
-	assert.Equal(t, mockkmsg.seekCalls, [][2]int64{{0, int64(io.SeekEnd)}})
-
-}
-
-type mseeker struct {
-	io.ReadCloser
-	seekCalls [][2]int64
-}
-
-func mockSeeker(rc io.ReadCloser) *mseeker {
-	return &mseeker{ReadCloser: rc}
-}
-
-func (m *mseeker) Seek(x int64, y int) (int64, error) {
-	m.seekCalls = append(m.seekCalls, [2]int64{x, int64(y)})
-	return 0, nil
 }

--- a/kmsgparser/log.go
+++ b/kmsgparser/log.go
@@ -19,16 +19,15 @@ package kmsgparser
 import stdlog "log"
 
 // Logger is a glog compatible logging interface
-// The StandardLogger struct can be used to wrap a log.Logger from the golang
-// "log" package to create a standard a logger fulfilling this interface as
-// well.
+// The [StandardLogger] struct can be used to convert a [log.Logger] into this
+// interface.
 type Logger interface {
 	Warningf(string, ...interface{})
 	Infof(string, ...interface{})
 	Errorf(string, ...interface{})
 }
 
-// StandardLogger adapts the "log" package's Logger interface to be a Logger
+// StandardLogger adapts the [log.Logger] interface to be a [Logger].
 type StandardLogger struct {
 	*stdlog.Logger
 }


### PR DESCRIPTION
This requires putting the fd into nonblocking mode, but keeping it outside of the epoll runtime stuff.

As such, it's implemented as a separate codepath to contain the hackiness.

This is a breaking change, so v3

I also dropped some tests that are tricky to implement since mocking /dev/kmsg semantics in go is a bit annoying.

I also updated `Parse` to take a channel as an input and not spin off its own goroutine. This gives a better api, and most notably better error handling.